### PR TITLE
Internet Explorer does not support closest

### DIFF
--- a/doc/article/en-US/validation-basics.md
+++ b/doc/article/en-US/validation-basics.md
@@ -458,9 +458,13 @@ Custom renderers implement a one-method interface: `render(instruction: RenderIn
       }
 
       private add(element: Element, error: ValidationError) {
-        const formGroup = element.closest('.form-group');
-        if (!formGroup) {
-          return;
+        let formGroup = target.parentElement;
+        while (formGroup.nodeName !== "BODY" && !formGroup.classList.contains('form-group')) {
+            formGroup = formGroup.parentElement;
+        }
+
+        if (formGroup.nodeName === "BODY") {
+            return;
         }
         
         // add the has-error class to the enclosing form-group div
@@ -475,9 +479,13 @@ Custom renderers implement a one-method interface: `render(instruction: RenderIn
       }
 
       private remove(element: Element, error: ValidationError) {
-        const formGroup = element.closest('.form-group');
-        if (!formGroup) {
-          return;
+        let formGroup = target.parentElement;
+        while (formGroup.nodeName !== "BODY" && !formGroup.classList.contains('form-group')) {
+            formGroup = formGroup.parentElement;
+        }
+
+        if (formGroup.nodeName === "BODY") {
+            return;
         }
 
         // remove help-block


### PR DESCRIPTION
I did not test the code before pushing the button. I made some changes that are not in my code. I also added the extra check to see if we traversed back to BODY.

I don't see it in this implementation but I also had to change `message.remove()` to `message.parentNode.removeChild(message);`
